### PR TITLE
target parent & display Name vs. Id

### DIFF
--- a/src/classes/CRL_MetaGeneratorCtrl.cls
+++ b/src/classes/CRL_MetaGeneratorCtrl.cls
@@ -104,7 +104,7 @@ public with sharing class CRL_MetaGeneratorCtrl {
 			'					<apex:pageBlock title="' + this.crl.name + '">\n' +
 			'							<apex:pageBlockTable var="row" value="{!FilteredList}">\n' +
 			'									<apex:column headerValue="Link">\n' +
-			'											<apex:outputLink value="/{!row.Id}">{!row.id}</apex:outputLink>\n' +
+			'											<apex:outputLink value="/{!row.Id}" target="_parent">{!row.name}</apex:outputLink>\n' +
 			'									</apex:column>\n' +
 			'									<apex:repeat value="{!qt.columnTitles}" var="col">\n' +
 			'											<apex:column headerValue="{!qt.columnLabels[col]}">\n' +


### PR DESCRIPTION
I updated this so that when you click the link it targets the parent page.  I also changed it to display the row.name instead of row.id, more closely mimicking how standard related lists work
